### PR TITLE
Added better Loader support for long-running sync reqs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 
 .idea
 .pytest_cache
+.venv
+venv

--- a/ranger/core/loader.py
+++ b/ranger/core/loader.py
@@ -414,6 +414,7 @@ class Loader(FileManagerAware):
                 if self.pending_future is None:
                     self.pending_future = Loader.executor.submit(next, item.load_generator)
                 self.pending_future.result(timeout=self.seconds_of_work_time)
+                self.pending_future = None
             except concurrent.futures.TimeoutError:
                 break
             except StopIteration:


### PR DESCRIPTION
* Now one blocking next(item.load_generator) is replaced with a async
one
* This also has effect that single long item.load_generator is not
blocking the whole event loop

WARNING: Currently broken:

```
ranger version: ranger-master 1.9.1
Python version: 3.6.5 (default, Apr 14 2018, 13:17:30) [GCC 7.3.1 20180406]
Locale: en_US.UTF-8
Current file: '/home/lpp/Desktop/ranger/CHANGELOG.md'

Traceback (most recent call last):
  File "/home/lpp/Desktop/ranger/ranger/core/main.py", line 195, in main
    fm.loop()
  File "/home/lpp/Desktop/ranger/ranger/core/fm.py", line 384, in loop
    loader.work()
  File "/home/lpp/Desktop/ranger/ranger/core/loader.py", line 406, in work
    self.old_item.pause()
  File "/home/lpp/Desktop/ranger/ranger/core/loader.py", line 245, in pause
    self.process.send_signal(20)
AttributeError: 'NoneType' object has no attribute 'send_signal'
```